### PR TITLE
Add shortcuts for helpers

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -59,5 +59,7 @@ require('yargs') // eslint-disable-line
     ftrace(argv.function_identifier, argv.function_visibility_restrictor, argv.files)
   })
   .help()
+  .alias('h', 'help')
   .version()
+  .alias('v', 'version')
   .argv


### PR DESCRIPTION
Makes `--help` and `--version` callable with `-h` and `-v`