### PR TITLE
solution for periods in subgraph name breaking dot

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -349,12 +349,6 @@ key:i2:e -> key2:i2:w [color=orange]
 }
 `
   let finalDigraph = utils.insertBeforeLastOccurrence(digraph.to_dot(), '}', legendDotString)
-  
-  // wraps subgraph names in quotes so periods can be used without breaking dot
-  // i.e. subgraph clusterContractName.VariableName
-  // becomes
-  // subgraph "clusterContractName.VariableName"
-  finalDigraph = finalDigraph.replace(/(cluster\S+)/ig, '"$&"')
 
   console.log(finalDigraph)
 }

--- a/src/graph.js
+++ b/src/graph.js
@@ -52,8 +52,8 @@ export function graph(files) {
 
         let opts = {}
 
-        if(!(cluster = digraph.getCluster('cluster' + contractName))) {
-          cluster = digraph.addCluster('cluster' + contractName)
+        if(!(cluster = digraph.getCluster(`"cluster${contractName}"`))) {
+          cluster = digraph.addCluster(`"cluster${contractName}"`)
 
           cluster.set('label', contractName)
           cluster.set('color', 'lightgray')
@@ -131,7 +131,7 @@ export function graph(files) {
       ContractDefinition(node) {
         contractName = node.name
 
-        cluster = digraph.getCluster('cluster' + contractName)
+        cluster = digraph.getCluster(`"cluster${contractName}"`)
       },
 
       FunctionDefinition(node) {
@@ -295,8 +295,8 @@ export function graph(files) {
 
         let externalCluster
 
-        if(!(externalCluster = digraph.getCluster('cluster' + localContractName))) {
-          externalCluster = digraph.addCluster('cluster' + localContractName)
+        if(!(externalCluster = digraph.getCluster(`"cluster${localContractName}"`))) {
+          externalCluster = digraph.addCluster(`"cluster${localContractName}"`)
 
           externalCluster.set('label', localContractName)
           externalCluster.set('color', 'lightgray')
@@ -349,6 +349,12 @@ key:i2:e -> key2:i2:w [color=orange]
 }
 `
   let finalDigraph = utils.insertBeforeLastOccurrence(digraph.to_dot(), '}', legendDotString)
+  
+  // wraps subgraph names in quotes so periods can be used without breaking dot
+  // i.e. subgraph clusterContractName.VariableName
+  // becomes
+  // subgraph "clusterContractName.VariableName"
+  finalDigraph = finalDigraph.replace(/(cluster\S+)/ig, '"$&"')
 
   console.log(finalDigraph)
 }


### PR DESCRIPTION
Problem: If a subgraph name was generated for a variable it would break the bash piping to `dot`. 

Solution: wrapped the subgraph name in double quotes so that 
`subgraph clusterContractName.VariableName`
becomes
`subgraph "clusterContractName.VariableName"`