### PR TITLE
Show "NO!" for methods open for external calls without modifiers

### DIFF
--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -28,6 +28,8 @@ export function mdreport(outfile, infiles) {
 
     const content = fs.readFileSync(file).toString('utf-8')
     const ast = parser.parse(content)
+    var isPublic = false
+    var isModifierExists = false;
 
     parser.visit(ast, {
       ContractDefinition(node) {
@@ -53,6 +55,8 @@ export function mdreport(outfile, infiles) {
 
       FunctionDefinition(node) {
         let name
+        isPublic = false
+        isModifierExists = false
 
         if (node.isConstructor) {
           name = '\\<Constructor\\>'
@@ -66,8 +70,10 @@ export function mdreport(outfile, infiles) {
         let spec = ''
         if (node.visibility === 'public' || node.visibility === 'default') {
           spec += 'Public ❗️'
+          isPublic = true
         } else if (node.visibility === 'external') {
           spec += 'External ❗️'
+          isPublic = true
         } else if (node.visibility === 'private') {
           spec += 'Private 🔐'
         } else if (node.visibility === 'internal') {
@@ -88,12 +94,17 @@ export function mdreport(outfile, infiles) {
       },
 
       'FunctionDefinition:exit': function(node) {
+        if (isPublic && !isModifierExists) {
+          contractsTable += '☠️'
+        }
         contractsTable += ` |
 `
       },
 
       ModifierInvocation(node) {
-        contractsTable += ` ${node.name}`
+        isModifierExists = true
+        contractsTable += ` ${node.name}`          
+        
       }
     })
   }

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -29,7 +29,8 @@ export function mdreport(outfile, infiles) {
     const content = fs.readFileSync(file).toString('utf-8')
     const ast = parser.parse(content)
     var isPublic = false
-    var isModifierExists = false;
+    var isModifierExists = false
+    var isConstructor = false;
 
     parser.visit(ast, {
       ContractDefinition(node) {
@@ -57,8 +58,10 @@ export function mdreport(outfile, infiles) {
         let name
         isPublic = false
         isModifierExists = false
+        isConstructor = false
 
         if (node.isConstructor) {
+          isConstructor = true
           name = '\\<Constructor\\>'
         } else if (!node.name) {
           name = '\\<Fallback\\>'
@@ -94,8 +97,8 @@ export function mdreport(outfile, infiles) {
       },
 
       'FunctionDefinition:exit': function(node) {
-        if (isPublic && !isModifierExists) {
-          contractsTable += '☠️'
+        if (!isConstructor && isPublic && !isModifierExists) {
+          contractsTable += 'NO❗️'
         }
         contractsTable += ` |
 `


### PR DESCRIPTION
I did some changes for md-report. It now shows "NO❗️" in Modifiers column for methods those are public/default/external and there are no modifiers present for the method.

This change would give reviewers the idea that this function call could have potential flaws. It has to be reviewed.