### PR TITLE
When no modifier and external calls show "NO❗️" for modifiers

### DIFF
--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -29,7 +29,7 @@ export function mdreport(outfile, infiles) {
     const content = fs.readFileSync(file).toString('utf-8')
     const ast = parser.parse(content)
     var isPublic = false
-    var isModifierExists = false
+    var doesModifierExist = false
     var isConstructor = false;
 
     parser.visit(ast, {
@@ -57,7 +57,7 @@ export function mdreport(outfile, infiles) {
       FunctionDefinition(node) {
         let name
         isPublic = false
-        isModifierExists = false
+        doesModifierExist = false
         isConstructor = false
 
         if (node.isConstructor) {
@@ -97,7 +97,7 @@ export function mdreport(outfile, infiles) {
       },
 
       'FunctionDefinition:exit': function(node) {
-        if (!isConstructor && isPublic && !isModifierExists) {
+        if (!isConstructor && isPublic && !doesModifierExist) {
           contractsTable += 'NO❗️'
         }
         contractsTable += ` |
@@ -105,7 +105,7 @@ export function mdreport(outfile, infiles) {
       },
 
       ModifierInvocation(node) {
-        isModifierExists = true
+        doesModifierExist = true
         contractsTable += ` ${node.name}`          
         
       }

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -28,6 +28,9 @@ export function mdreport(outfile, infiles) {
 
     const content = fs.readFileSync(file).toString('utf-8')
     const ast = parser.parse(content)
+    var isPublic = false
+    var isModifierExists = false
+    var isConstructor = false;
 
     parser.visit(ast, {
       ContractDefinition(node) {
@@ -53,8 +56,12 @@ export function mdreport(outfile, infiles) {
 
       FunctionDefinition(node) {
         let name
+        isPublic = false
+        isModifierExists = false
+        isConstructor = false
 
         if (node.isConstructor) {
+          isConstructor = true
           name = '\\<Constructor\\>'
         } else if (!node.name) {
           name = '\\<Fallback\\>'
@@ -66,8 +73,10 @@ export function mdreport(outfile, infiles) {
         let spec = ''
         if (node.visibility === 'public' || node.visibility === 'default') {
           spec += 'Public ❗️'
+          isPublic = true
         } else if (node.visibility === 'external') {
           spec += 'External ❗️'
+          isPublic = true
         } else if (node.visibility === 'private') {
           spec += 'Private 🔐'
         } else if (node.visibility === 'internal') {
@@ -88,12 +97,17 @@ export function mdreport(outfile, infiles) {
       },
 
       'FunctionDefinition:exit': function(node) {
+        if (!isConstructor && isPublic && !isModifierExists) {
+          contractsTable += 'NO❗️'
+        }
         contractsTable += ` |
 `
       },
 
       ModifierInvocation(node) {
-        contractsTable += ` ${node.name}`
+        isModifierExists = true
+        contractsTable += ` ${node.name}`          
+        
       }
     })
   }


### PR DESCRIPTION
I did some changes for md-report. It now shows "NO❗️" in Modifiers column for methods those are public/default/external and there are no modifiers present for the method.

This change would give reviewers the idea that this function call could have potential flaws. It has to be reviewed.