### PR TITLE
Delete lib prior to compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "bin": "./bin/surya",
   "scripts": {
-    "compile": "babel src --out-dir lib",
+    "compile": "rm -rf lib && babel src --out-dir lib",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "prepare": "npm run compile",
     "test": "./test/test.sh"


### PR DESCRIPTION
I was getting annoyed by residual files in `lib` that are no longer in `src`.  So I changed the compile script to delete the `lib` dir first. I also removed a `prepare` script that was redundant with `compile`.

