### PR TITLE
turn surya into a library (minimal changes)

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+const fs = require('fs')
 const { describe, graph, inheritance, dependencies, parse, ftrace, mdreport } = require('../lib/index')
 
 require('yargs') // eslint-disable-line
@@ -20,7 +20,7 @@ require('yargs') // eslint-disable-line
         type: 'string'
       })
   }, (argv) => {
-    graph(argv.files)
+    console.log(graph(argv.files))
   })
   .command('inheritance <files..>', 'generate graph of contract inheritance tree.', (yargs) => {
     yargs
@@ -34,7 +34,7 @@ require('yargs') // eslint-disable-line
         defalt: false
       })
   }, (argv) => {
-    inheritance(argv.files, {draggable: argv.d})
+    console.log(inheritance(argv.files, {draggable: argv.d}))
   })
   .command('dependencies <target_contract> <files..>', 'output a linearized list of smart contract dependencies (linerized inherited parents).', (yargs) => {
     yargs
@@ -56,7 +56,7 @@ require('yargs') // eslint-disable-line
         type: 'string'
       })
   }, (argv) => {
-    parse(argv.file)
+    console.log(parse(argv.file))
   })
   .command('ftrace <function_identifier> <function_visibility_restrictor> <files..>', 'output the selected function call trace in a textual tree format. External calls are marked in `orange` and internal calls are `uncolored`.', (yargs) => {
     yargs
@@ -74,7 +74,7 @@ require('yargs') // eslint-disable-line
         type: 'string'
       })
   }, (argv) => {
-    ftrace(argv.function_identifier, argv.function_visibility_restrictor, argv.files)
+    console.log(ftrace(argv.function_identifier, argv.function_visibility_restrictor, argv.files))
   })
   .command('mdreport <outfile> <infiles..>', 'output a markdown file ', (yargs) => {
     yargs
@@ -87,7 +87,12 @@ require('yargs') // eslint-disable-line
         type: 'string'
       })
   }, (argv) => {
-    mdreport(argv.outfile, argv.infiles)
+    try {
+      fs.writeFileSync(argv.outfile, mdreport(argv.infiles), {flag: 'w'})
+    } catch (err) {
+        console.log('Error in writing report file')
+        console.log(err)
+    }
   })
   .help()
   .alias('h', 'help')

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -341,5 +341,5 @@ export function ftrace(functionId, accepted_visibility, files) {
   // Call with seed
   constructCallTree(contractToTraverse, functionToTraverse, callTree[seedKeyString])
 
-  console.log(treeify.asTree(callTree, true))
+  return treeify.asTree(callTree, true)
 }

--- a/src/graph.js
+++ b/src/graph.js
@@ -350,5 +350,5 @@ key:i2:e -> key2:i2:w [color=orange]
 `
   let finalDigraph = utils.insertBeforeLastOccurrence(digraph.to_dot(), '}', legendDotString)
 
-  console.log(finalDigraph)
+  return finalDigraph
 }

--- a/src/inheritance.js
+++ b/src/inheritance.js
@@ -83,9 +83,9 @@ export function inheritance(files, options) {
   }
 
   if (options.draggable) {
-    console.log(reportGenerate(definition))
+    return reportGenerate(definition)
   } else {
-    console.log(digraph.to_dot())
+    return digraph.to_dot()
   }
 }
 

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -5,7 +5,7 @@ const parser = require('solidity-parser-antlr')
 const colors = require('colors')
 const sha1File = require('sha1-file')
 
-export function mdreport(outfile, infiles) {
+export function mdreport(infiles) {
   if (infiles.length === 0) {
     console.log('No files were specified for analysis in the arguments. Bailing...')
     return
@@ -130,10 +130,5 @@ ${contractsTable}
 |    💵    | Function is payable |
 `
   
-  try {
-    fs.writeFileSync(outfile, reportContents, {flag: 'w'})
-  } catch (err) {
-      console.log('Error in writing report file')
-      console.log(err)
-  }
+  return reportContents
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -14,5 +14,5 @@ export function parse(file) {
     //   }
     // }); 
 
-    console.log( treeify.asTree(ast, true) )
+    return treeify.asTree(ast, true)
 }


### PR DESCRIPTION
Hey @GNSPS 👋 

I'd like to use surya features (graph, ftrace) with vscode-solidity-auditor already and therefore need it to act as a library besides being a cmdline tool. this PR provides minimal changes in order to make that happen :) (dependency and describe is still only available via console unless we make it return a usable structure, but thats fine so war 👍 )

* surya cmdline tool still works as expected
* additionally allows to use it as a lib now as well returning data when calling the various functions

surya is pretty cool! thx for sharing!

cheers,
tin

//commitlog
 - minimal changes to allow other tools to import surya and call the
 various methods
 - surya features now returning data instead of printing it to console
 - bin/surya cmdline util decides to print to console