### PR TITLE
update graphviz to 0.0.9 (fixes issues)

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -31,7 +31,7 @@ require('yargs') // eslint-disable-line
       .option('d', {
         alias: 'draggable',
         type: 'boolean',
-        defalt: false
+        default: false
       })
   }, (argv) => {
     console.log(inheritance(argv.files, {draggable: argv.d}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,9 +1926,9 @@
       "dev": true
     },
     "graphviz": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.8.tgz",
-      "integrity": "sha1-5ZnkBzPvgOFlO/6JpfAx7PKqSqo=",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
+      "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
       "requires": {
         "temp": "~0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colors": "^1.3.0",
     "detect-installed": "^2.0.4",
     "dot-object": "^1.7.0",
-    "graphviz": "0.0.8",
+    "graphviz": "0.0.9",
     "jquery": "3.3.1",
     "jsplumb": "2.7.13",
     "sha1-file": "^1.0.1",


### PR DESCRIPTION
* graphviz recently fixed some weird issues (v0.0.8 wont work with vscode because of what they do to js arrays....) v0.0.9 appears to work now
* fixed typo