### PR TITLE
feat/no-color-output

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const colors = require('colors')
 const importer = require('../lib/utils/importer')
-const { describe, graph, inheritance, dependencies, flatten, parse, ftrace, mdreport } = require('../lib/index')
+const { describe, graph, inheritance, dependenciesPrint, flatten, parse, ftrace, mdreport } = require('../lib/index')
 
 require('yargs') // eslint-disable-line
   .usage('$0 <cmd> [args]')
@@ -81,19 +81,7 @@ require('yargs') // eslint-disable-line
     if(argv.i) {
       files = importer.importProfiler(argv.files)
     }
-    let derivedLinearization = dependencies(files, argv.target_contract)
-    if(derivedLinearization){
-      console.log(derivedLinearization[0].yellow)
-  
-      if (derivedLinearization.length < 2) {
-        console.log('No Dependencies Found')
-        return
-      }
-      derivedLinearization.shift()
-
-      const reducer = (accumulator, currentValue) => `${accumulator}\n  ↖ ${currentValue}`
-      console.log(`  ↖ ${derivedLinearization.reduce(reducer)}`)
-    }
+    console.log(dependenciesPrint(files, argv.target_contract))
   })
   .command('flatten <files..>', 'output to a single flattened solidity file', (yargs) => {
     yargs

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -60,3 +60,32 @@ export function dependencies(files, childContract) {
 
   return dependencies[childContract]
 }
+
+/**
+ * A function designed to return a nicely formatted string to be printed
+ * @param  {array} files A list of files required to resolve dependency graph
+ * @param  {string} childContract The name of the contract to derive
+ * @returns {array} A c3-linearized list of the of the dependency graph
+ */
+export function dependenciesPrint(files, childContract, noColorOutput = false) {
+  let outputString = ''
+
+  let derivedLinearization = dependencies(files, childContract)
+
+  if(derivedLinearization){
+    outputString += noColorOutput ? derivedLinearization[0] : derivedLinearization[0].yellow
+    
+    if (derivedLinearization.length < 2) {
+      outputString += `
+No Dependencies Found`
+      return outputString
+    }
+    derivedLinearization.shift()
+
+    const reducer = (accumulator, currentValue) => `${accumulator}\n  ↖ ${currentValue}`
+    outputString += `
+  ↖ ${derivedLinearization.reduce(reducer)}`
+  }
+
+  return outputString
+}

--- a/src/describe.js
+++ b/src/describe.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const parser = require('solidity-parser-antlr')
 
-export function describe(files) {
+export function describe(files, noColorOutput = false) {
   for (let file of files) {
     const content = fs.readFileSync(file).toString('utf-8')
     const ast = parser.parse(content)
@@ -16,13 +16,17 @@ export function describe(files) {
           return spec.baseName.namePath
         }).join(', ')
 
-        bases = bases.length ? `(${bases})`.gray : ''
+        bases = bases.length ? 
+                  noColorOutput ?
+                    `(${bases})`
+                    : `(${bases})`.gray
+                  : ''
 
         let specs = ''
         if (node.kind === 'library') {
-          specs += '[Lib]'.yellow
+          specs += noColorOutput ? '[Lib]' : '[Lib]'.yellow
         } else if (node.kind === 'interface') {
-          specs += '[Int]'.blue
+          specs += noColorOutput ? '[Int]' : '[Int]'.blue
         }
 
         console.log(` + ${specs} ${name} ${bases}`)
@@ -36,32 +40,32 @@ export function describe(files) {
         let name
 
         if (node.isConstructor) {
-          name = '<Constructor>'.gray
+          name = noColorOutput ? '<Constructor>' : '<Constructor>'.gray
         } else if (!node.name) {
-          name = '<Fallback>'.gray
+          name = noColorOutput ? '<Fallback>' : '<Fallback>'.gray
         } else {
           name = node.name
         }
 
         let spec = ''
         if (node.visibility === 'public' || node.visibility === 'default') {
-          spec += '[Pub]'.green
+          spec += noColorOutput ? '[Pub]' : '[Pub]'.green
         } else if (node.visibility === 'external') {
-          spec += '[Ext]'.blue
+          spec += noColorOutput ? '[Ext]' : '[Ext]'.blue
         } else if (node.visibility === 'private') {
-          spec += '[Prv]'.red
+          spec += noColorOutput ? '[Prv]' : '[Prv]'.red
         } else if (node.visibility === 'internal') {
-          spec += '[Int]'.gray
+          spec += noColorOutput ? '[Int]' : '[Int]'.gray
         }
 
         let payable = ''
         if (node.stateMutability === 'payable') {
-          payable = ' ($)'.yellow
+          payable = noColorOutput ? ' ($)' : ' ($)'.yellow
         }
 
         let mutating = ''
         if (!node.stateMutability) {
-          mutating = ' #'.red
+          mutating = noColorOutput ? ' #' : ' #'.red
         }
 
         console.log(`    - ${spec} ${name}${payable}${mutating}`)
@@ -70,8 +74,8 @@ export function describe(files) {
   }
 
   // Print a legend for symbols being used
-  let mutationSymbol = ' #'.red
-  let payableSymbol = ' ($)'.yellow
+  let mutationSymbol = noColorOutput ? ' #' : ' #'.red
+  let payableSymbol = noColorOutput ? ' ($)' : ' ($)'.yellow
 
   console.log(`
 ${payableSymbol} = payable function

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -9,20 +9,17 @@ const treeify = require('treeify')
 
 export function ftrace(functionId, accepted_visibility, files) {
   if (files.length === 0) {
-    console.error('No files were specified for analysis in the arguments. Bailing...')
-    return
+    return 'No files were specified for analysis in the arguments. Bailing...'
   }
 
   const [contractToTraverse, functionToTraverse] = functionId.split('::', 2)
 
   if (contractToTraverse === undefined || functionToTraverse === undefined) {
-    console.error('You did not provide the function identifier in the right format "CONTRACT::FUNCTION"')
-    return
+    return 'You did not provide the function identifier in the right format "CONTRACT::FUNCTION"'
   }
 
   if (accepted_visibility !== 'all' && accepted_visibility !== 'internal' && accepted_visibility !== 'external') {
-    console.error(`The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`)
-    return
+    return `The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`
   }
 
   let functionCallsTree = {}
@@ -264,11 +261,9 @@ export function ftrace(functionId, accepted_visibility, files) {
   let callTree = {}
 
   if(!functionCallsTree.hasOwnProperty(contractToTraverse)) {
-    console.log(`The ${contractToTraverse} contract is not present in the codebase.`.yellow)
-    return
+    return `The ${contractToTraverse} contract is not present in the codebase.`
   } else if (!functionCallsTree[contractToTraverse].hasOwnProperty(functionToTraverse)) {
-    console.log(`The ${functionToTraverse} function is not present in ${contractToTraverse}.`.yellow)
-    return
+    return `The ${functionToTraverse} function is not present in ${contractToTraverse}.`
   }
 
   const seedKeyString = `${contractToTraverse}::${functionToTraverse}`.green

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -7,7 +7,7 @@ const { linearize } = require('c3-linearization')
 const treeify = require('treeify')
 
 
-export function ftrace(functionId, accepted_visibility, files) {
+export function ftrace(functionId, accepted_visibility, files, noColorOutput = false) {
   if (files.length === 0) {
     return 'No files were specified for analysis in the arguments. Bailing...'
   }
@@ -309,8 +309,9 @@ export function ftrace(functionId, accepted_visibility, files) {
 
         keyString += functionDecorators[functionCallName] === undefined ? '' : functionDecorators[functionCallName]
 
-        keyString = functionCallObject.visibility === 'external' && accepted_visibility !== 'external'
-                    ? keyString.yellow : keyString
+        if(!noColorOutput && functionCallObject.visibility === 'external' && accepted_visibility !== 'external') {
+          keyString = keyString.yellow
+        }
 
         if(touched[keyString] === undefined) {
           parentObject[keyString] = {}
@@ -323,8 +324,10 @@ export function ftrace(functionId, accepted_visibility, files) {
           }
         } else {
           parentObject[keyString] = Object.keys(functionCallsTree[functionCallObject.contract][functionCallName]).length === 0 ?
-                                    {} :
-                                    '..[Repeated Ref]..'.red
+                                      {} :
+                                      noColorOutput ?
+                                        '..[Repeated Ref]..' :
+                                        '..[Repeated Ref]..'.red
         }
       }
     })

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -9,19 +9,19 @@ const treeify = require('treeify')
 
 export function ftrace(functionId, accepted_visibility, files) {
   if (files.length === 0) {
-    console.log('No files were specified for analysis in the arguments. Bailing...')
+    console.error('No files were specified for analysis in the arguments. Bailing...')
     return
   }
 
   const [contractToTraverse, functionToTraverse] = functionId.split('::', 2)
 
   if (contractToTraverse === undefined || functionToTraverse === undefined) {
-    console.log('You did not provide the function identifier in the right format "CONTRACT::FUNCTION"')
+    console.error('You did not provide the function identifier in the right format "CONTRACT::FUNCTION"')
     return
   }
 
   if (accepted_visibility !== 'all' && accepted_visibility !== 'internal' && accepted_visibility !== 'external') {
-    console.log(`The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`)
+    console.error(`The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`)
     return
   }
 

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -16,12 +16,12 @@ export function ftrace(functionId, accepted_visibility, files) {
   const [contractToTraverse, functionToTraverse] = functionId.split('::', 2)
 
   if (contractToTraverse === undefined || functionToTraverse === undefined) {
-    console.log('You did not provide the function identifier in the right format "CONTRACT::FUNCTION"'.yellow)
+    console.log('You did not provide the function identifier in the right format "CONTRACT::FUNCTION"')
     return
   }
 
   if (accepted_visibility !== 'all' && accepted_visibility !== 'internal' && accepted_visibility !== 'external') {
-    console.log(`The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`.yellow)
+    console.log(`The "${accepted_visibility}" type of call to traverse is not known [all|internal|external]`)
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 export { describe } from './describe'
 export { graph } from './graph'
 export { inheritance } from './inheritance'
-export { dependencies } from './dependencies'
+export { dependenciesPrint } from './dependencies'
 export { parse } from './parse'
 export { ftrace } from './ftrace'
 export { mdreport } from './mdreport'


### PR DESCRIPTION
Add an optional parameter to all the module functions to discard color decorators from the output.

This is so that we make it easier for VSCode's Solidity Visual Auditor extension to show the describe command in the IDE.