### PR TITLE
Option to specify `mdreport` markdown title deepness

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -127,9 +127,14 @@ require('yargs') // eslint-disable-line
         type: 'boolean',
         default: false
       })
+      .option('d', {
+        alias: 'title-deepness',
+        type: 'number',
+        default: 2
+      })
   }, (argv) => {
     try {
-      fs.writeFileSync(argv.outfile, mdreport(argv.infiles, {importer: argv.i}), {flag: 'w',})
+      fs.writeFileSync(argv.outfile, mdreport(argv.infiles, {importer: argv.i, deepness: argv.d}), {flag: 'w',})
     } catch (err) {
         console.log('Error in writing report file')
         console.log(err)

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -120,17 +120,17 @@ export function mdreport(infiles, options = {}) {
     })
   }
 
-  const reportContents = `## Sūrya's Description Report
+  const reportContents = `${'#'.repeat(options.deepness)} Sūrya's Description Report
 
-### Files Description Table
+${'#'.repeat(options.deepness + 1)} Files Description Table
 
 ${filesTable}
 
-### Contracts Description Table
+${'#'.repeat(options.deepness + 1)} Contracts Description Table
 
 ${contractsTable}
 
-### Legend
+${'#'.repeat(options.deepness + 1)} Legend
 
 |  Symbol  |  Meaning  |
 |:--------:|-----------|


### PR DESCRIPTION
Right now the default deepness keeps being `2` (as in `## `) but can be specified with the `-d` flag (`surya mdreport report.md Infile.sol -d 3` would create a title starting with `###`)

Do you want a different default, @smarx?