### PR TITLE
List modifiers in describe command

### DIFF
--- a/src/describe.js
+++ b/src/describe.js
@@ -109,7 +109,16 @@ export function describe(files, options = {}, noColorOutput = false) {
           mutating = noColorOutput ? ' #' : ' #'.red;
         }
 
-        console.log(`    - ${spec} ${name}${payable}${mutating}`);
+        let modifiers = ''
+        for (let m of node.modifiers) {
+          if (!!modifiers) modifiers += ','
+          modifiers += m.name
+        }
+
+        console.log(`    - ${spec} ${name}${payable}${mutating}`)
+        if (!!modifiers) {
+          console.log(`       - modifiers: ${modifiers}`)
+        }
       }
     });
   }


### PR DESCRIPTION
This is a simple change to add a list of modifiers, when present, on a new line. 

If desired, we could add a flag to make this behavior optional.

Example:

Pool (Initializable, ReentrancyGuard)
    - [Pub] init #
       - modifiers: initializer
    - [Int] open #
    - [Int] commit #
    - [Pub] openNextDraw #
       - modifiers: onlyAdmin,unlessPaused
    - [Pub] rewardAndOpenNextDraw #
       - modifiers: onlyAdmin,unlessPaused
    - [Int] reward #
    - [Int] calculateFee
    - [Pub] depositSponsorship #
       - modifiers: nonReentrant,unlessPaused
    - [Pub] depositPool #
       - modifiers: requireOpenDraw,nonReentrant,unlessPaused