### PR TITLE
distinguish emit Event from Function Call - fixes #105

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -250,6 +250,7 @@ export function graph(files, options = {}) {
     let localVars = {};
     let tempUserDefinedStateVars = {};
     let tempStateVars = {};
+    let eventDefinitions = [];
 
     parser.visit(ast, {
       ContractDefinition(node) {
@@ -262,6 +263,10 @@ export function graph(files, options = {}) {
 
         Object.assign(tempUserDefinedStateVars, userDefinedStateVars[contractName]);
         Object.assign(tempStateVars, stateVars[contractName]);
+      },
+
+      EventDefinition(node) {
+        eventDefinitions.push(node.name);
       },
 
       'ContractDefinition:exit': function(node) {
@@ -453,7 +458,16 @@ export function graph(files, options = {}) {
         let localNodeName = nodeName(name, localContractName);
 
         if (!digraph.getNode(localNodeName) && externalCluster) {
-          externalCluster.addNode(localNodeName, { label: name});
+          let _opts = {
+            label: name
+          };
+          if(colorScheme.event && eventDefinitions.includes(name)){
+            //emit event
+            _opts.color = colorScheme.event.color;
+            _opts.shape = colorScheme.event.shape;
+            _opts.style = colorScheme.event.style;
+          }
+          externalCluster.addNode(localNodeName, _opts);
         }
 
         digraph.addEdge(callingScope, localNodeName, opts);

--- a/src/utils/colorscheme.js
+++ b/src/utils/colorscheme.js
@@ -22,6 +22,9 @@ export const defaultColorScheme = {
         regular: "green",
         this: "green"
     },
+    event: {
+        style: "dotted"
+    },
     contract: {
         defined: {
             bgcolor: "lightgray",
@@ -66,6 +69,9 @@ export const defaultColorSchemeDark = {
         default: "white",
         regular: "#1bc6a6",
         this: "#80e097"
+    },
+    event: {
+        style: "dotted"
     },
     contract: {
         defined: {

--- a/src/utils/parserHelpers.js
+++ b/src/utils/parserHelpers.js
@@ -12,7 +12,7 @@ function isLowerCase(str) {
 const parserHelpers = {
   isRegularFunctionCall: (node, contractNames) => {
     const expr = node.expression;
-    return expr.type === 'Identifier'
+    return expr && expr.type === 'Identifier'
         && !contractNames.includes(expr.name)
         && !BUILTINS.includes(expr.name);
   },


### PR DESCRIPTION
Events are currently shown as normal function nodes. This PR aims to visually distinguish events from functions. The style can be defined with the colorscheme. This example uses dotted lines for events (default). Feel free to change this before merging :) 


example: `MatchWithOrders` is an event (`emit MatchWithOrders(...)`)

![image](https://user-images.githubusercontent.com/2865694/84296573-7d85b400-ab4c-11ea-9111-a3b8ccc5f909.png)


I've also added a small fix for `parserHelpers` to make the check more robust.