### PR TITLE
Update solidity parser to ^0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       "dev": true
     },
     "@solidity-parser/parser": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.1.tgz",
-      "integrity": "sha512-MUA5kP9LdeTILeOsaz/k/qA4MdTNUxrn6q6HMYsMzQN5crU9bWKND2DaoWZhzofQM0VaTOaD8GFkCw1BYbNj5w=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.7.1.tgz",
+      "integrity": "sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       "dev": true
     },
     "@solidity-parser/parser": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.7.1.tgz",
-      "integrity": "sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.0.tgz",
+      "integrity": "sha512-4Eg1iWe6ZuJC9Ynfd8D2cnu06So0QL6V3i+fgQRqT8twPMr+N+kUvS5K7ILgWpuoAag/jb3r0wBDfmpib+yvaw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sinon": "^5.1.1"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.6.1",
+    "@solidity-parser/parser": "^0.7.1",
     "c3-linearization": "^0.3.0",
     "colors": "^1.4.0",
     "graphviz": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sinon": "^5.1.1"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.7.1",
+    "@solidity-parser/parser": "^0.8.0",
     "c3-linearization": "^0.3.0",
     "colors": "^1.4.0",
     "graphviz": "0.0.9",


### PR DESCRIPTION
Update solidity-parser version to `^0.8.0` to avoid `Error: Constructors have to be declared either "public" or "internal"` using Solidity 0.7.x.

Closes #148 