### PR TITLE
Fix importer

### DIFF
--- a/src/utils/importer.js
+++ b/src/utils/importer.js
@@ -51,7 +51,7 @@ export function importProfiler(files, projectDir = process.cwd(), importedFiles 
     parser.visit(ast, {
       ImportDirective(node) {
         let newFile = resolveImportPath(file, node.path, projectDir);
-        newFiles.push(newFile);
+        if (!importedFiles.has(newFile)) newFiles.push(newFile);
       }
     });
     // Run through the array of files found in this file
@@ -73,7 +73,6 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
   const topmostDirArray = projectDir.split(path.sep);
   let resolvedPath;
   let baseDirPath = path.dirname(baseFilePath);
-  console.log(baseDirPath);
   // if it's a relative or absolute path:
   if (
     importedFilePath.slice(0,1) === '.'
@@ -86,10 +85,10 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
     let currentDir = path.resolve(baseDirPath, '..');
     let currentDirArray = baseDirPath.split(path.sep);
     let currentDirName = currentDirArray.pop();
-    
+    let nodeModulesDir = '';
+
     // while (currentDirName != 'contracts') {
-    while (!fs.readdirSync(currentDir).includes('node_modules')) {
-      console.log(currentDir);
+    while (!fs.readdirSync(currentDir).includes('node_modules') && !nodeModulesDir) {
       // since we already know the current file is inside the project dir we can check if the
       // folder array length for the current dir is smaller than the top-most one, i.e. we are 
       // still inside the project dir. If not, throw
@@ -102,9 +101,11 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
       currentDirName = currentDirArray.pop();
       currentDir = path.resolve(currentDir, '..');
     }
+    // if we've reached this point, then we have found the dir containing node_modules
+    nodeModulesDir = path.join(currentDir, 'node_modules');
 
     // join it all to get the file path
-    resolvedPath = path.join(currentDir, 'node_modules', importedFilePath);
+    resolvedPath = path.join(nodeModulesDir, importedFilePath);
   }
 
   // verify that the resolved path is actually a file

--- a/src/utils/importer.js
+++ b/src/utils/importer.js
@@ -73,6 +73,7 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
   const topmostDirArray = projectDir.split(path.sep);
   let resolvedPath;
   let baseDirPath = path.dirname(baseFilePath);
+  console.log(baseDirPath);
   // if it's a relative or absolute path:
   if (
     importedFilePath.slice(0,1) === '.'
@@ -85,8 +86,10 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
     let currentDir = path.resolve(baseDirPath, '..');
     let currentDirArray = baseDirPath.split(path.sep);
     let currentDirName = currentDirArray.pop();
-
-    while (currentDirName != 'contracts') {
+    
+    // while (currentDirName != 'contracts') {
+    while (!fs.readdirSync(currentDir).includes('node_modules')) {
+      console.log(currentDir);
       // since we already know the current file is inside the project dir we can check if the
       // folder array length for the current dir is smaller than the top-most one, i.e. we are 
       // still inside the project dir. If not, throw
@@ -95,7 +98,7 @@ export function resolveImportPath(baseFilePath, importedFilePath, projectDir = p
         project dir: ${projectDir}
         path: ${currentDir}`);
       }
-      // if we still aren't in a folder called 'contracts' go up one level
+      // if we still aren't in a folder containing 'node_modules' go up one level
       currentDirName = currentDirArray.pop();
       currentDir = path.resolve(currentDir, '..');
     }


### PR DESCRIPTION
I was running into an issue with the `-i` flag, and TBH I'm not sure how it ever actually worked without causing an infinite loop

The recursive call in `importProfiler()` was passing the same set of files as the top call, so the set never got smaller and the recursion never stopped.

This commit also introduces a small optimization to stop looking for the `node_modules` dir once its been found.