### PR TITLE
Initialize "perContract" objects 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surya",
-  "version": "0.4.6-dev.1",
+  "version": "0.4.6-dev.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surya",
-      "version": "0.4.6-dev.1",
+      "version": "0.4.6-dev.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@solidity-parser/parser": "^0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surya",
-  "version": "0.4.6-dev.0",
+  "version": "0.4.6-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surya",
-      "version": "0.4.6-dev.0",
+      "version": "0.4.6-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@solidity-parser/parser": "^0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.6-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solidity-parser/parser": "^0.13.2",
+        "@solidity-parser/parser": "^0.14",
         "c3-linearization": "^0.3.0",
         "colors": "^1.4.0",
         "graphviz": "0.0.9",
@@ -145,9 +145,9 @@
       "dev": true
     },
     "node_modules/@solidity-parser/parser": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
-      "integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -5541,9 +5541,9 @@
       "dev": true
     },
     "@solidity-parser/parser": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
-      "integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surya",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surya",
-      "version": "0.4.3",
+      "version": "0.4.4-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@solidity-parser/parser": "^0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surya",
-  "version": "0.4.5",
+  "version": "0.4.6-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surya",
-      "version": "0.4.5",
+      "version": "0.4.6-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@solidity-parser/parser": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surya",
   "description": "Sūrya, The Sun God: A set of utilities for inspecting the structure of Solidity contracts.",
-  "version": "0.4.6-dev.1",
+  "version": "0.4.6-dev.2",
   "main": "lib/index.js",
   "author": [
     "GNSPS"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surya",
   "description": "Sūrya, The Sun God: A set of utilities for inspecting the structure of Solidity contracts.",
-  "version": "0.4.5",
+  "version": "0.4.6-dev.0",
   "main": "lib/index.js",
   "author": [
     "GNSPS"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surya",
   "description": "Sūrya, The Sun God: A set of utilities for inspecting the structure of Solidity contracts.",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.0",
   "main": "lib/index.js",
   "author": [
     "GNSPS"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^5.1.1"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.13.2",
+    "@solidity-parser/parser": "^0.14",
     "c3-linearization": "^0.3.0",
     "colors": "^1.4.0",
     "graphviz": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surya",
   "description": "Sūrya, The Sun God: A set of utilities for inspecting the structure of Solidity contracts.",
-  "version": "0.4.6-dev.0",
+  "version": "0.4.6-dev.1",
   "main": "lib/index.js",
   "author": [
     "GNSPS"

--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -34,9 +34,9 @@ export function ftrace(functionId, accepted_visibility, files, options = {}, noC
   let stateVars = {};
   let dependencies = {};
 
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {'0_global':[]};
+  let eventsPerContract = {'0_global':[]};
+  let structsPerContract = {'0_global':[]};
   let contractUsingFor = {};
   let contractNames = ['0_global'];
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -47,7 +47,7 @@ export function graph(files, options = {}) {
   let eventsPerContract = {};
   let structsPerContract = {};
   let contractUsingFor = {};
-  let contractNames = [];
+  let contractNames = ['0_global'];
 
   for (let file of files) {
 
@@ -82,7 +82,7 @@ export function graph(files, options = {}) {
 
     fileASTs.push(ast);
 
-    let contractName = null;
+    let contractName = '0_global';
     let cluster = null;
 
     parser.visit(ast, {
@@ -130,9 +130,15 @@ export function graph(files, options = {}) {
           } 
         }
 
+        dependencies[contractName] = ['0_global'];
+
         dependencies[contractName] = node.baseContracts.map(spec =>
           spec.baseName.namePath
         );
+      },
+
+      'ContractDefinition:exit': function(node) {
+        contractName = '0_global';
       },
 
       StateVariableDeclaration(node) {
@@ -177,7 +183,7 @@ export function graph(files, options = {}) {
 
   for (let ast of fileASTs) {
 
-    let contractName = null;
+    let contractName = '0_global';
     let cluster = null;
 
     function nodeName(functionName, contractName) {
@@ -213,6 +219,10 @@ export function graph(files, options = {}) {
         contractName = node.name;
 
         cluster = digraph.getCluster(`"cluster${contractName}"`);
+      },
+
+      'ContractDefinition:exit': function(node) {
+        contractName = '0_global';
       },
 
       FunctionDefinition(node) {
@@ -285,7 +295,7 @@ export function graph(files, options = {}) {
       },
 
       'ContractDefinition:exit': function(node) {
-        contractName = null; 
+        contractName = '0_global'; 
         tempUserDefinedStateVars = {};
         tempStateVars = {};
       },

--- a/src/graph.js
+++ b/src/graph.js
@@ -43,9 +43,9 @@ export function graph(files, options = {}) {
   let stateVars = {};
   let dependencies = {};
   let fileASTs = [];
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {'0_global':[]};
+  let eventsPerContract = {'0_global':[]};
+  let structsPerContract = {'0_global':[]};
   let contractUsingFor = {};
   let contractNames = ['0_global'];
 

--- a/src/graphSimple.js
+++ b/src/graphSimple.js
@@ -43,9 +43,9 @@ export function graphSimple(files, options = {}) {
   let stateVars = {};
   let dependencies = {};
   let fileASTs = [];
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {null:[]};
+  let eventsPerContract = {null:[]};
+  let structsPerContract = {null:[]};
   let contractUsingFor = {};
   let contractNames = [];
 


### PR DESCRIPTION
- fixes parser error when parsing structs that are outside of contracts.