### PR TITLE
Initialize "perContract" objects 

### DIFF
--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -34,9 +34,9 @@ export function ftrace(functionId, accepted_visibility, files, options = {}, noC
   let stateVars = {};
   let dependencies = {};
 
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {'0_global':[]};
+  let eventsPerContract = {'0_global':[]};
+  let structsPerContract = {'0_global':[]};
   let contractUsingFor = {};
   let contractNames = ['0_global'];
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -129,12 +129,12 @@ export function graph(files, options = {}) {
             cluster.set('style', 'filled');
           } 
         }
-
-        dependencies[contractName] = ['0_global'];
-
+        
         dependencies[contractName] = node.baseContracts.map(spec =>
           spec.baseName.namePath
         );
+
+        dependencies[contractName].unshift('0_global');
       },
 
       'ContractDefinition:exit': function(node) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -43,9 +43,9 @@ export function graph(files, options = {}) {
   let stateVars = {};
   let dependencies = {};
   let fileASTs = [];
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {'0_global':[]};
+  let eventsPerContract = {'0_global':[]};
+  let structsPerContract = {'0_global':[]};
   let contractUsingFor = {};
   let contractNames = ['0_global'];
 

--- a/src/graphSimple.js
+++ b/src/graphSimple.js
@@ -43,9 +43,9 @@ export function graphSimple(files, options = {}) {
   let stateVars = {};
   let dependencies = {};
   let fileASTs = [];
-  let functionsPerContract = {};
-  let eventsPerContract = {};
-  let structsPerContract = {};
+  let functionsPerContract = {null:[]};
+  let eventsPerContract = {null:[]};
+  let structsPerContract = {null:[]};
   let contractUsingFor = {};
   let contractNames = [];
 

--- a/test/contracts/Global.sol
+++ b/test/contracts/Global.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+
+struct WithdrawData {
+    address channelAddress;
+    address assetId;
+    address payable recipient;
+    uint256 amount;
+    uint256 nonce;
+    address callTo;
+    bytes callData;
+}
+
+interface ICMCWithdraw {
+    function getWithdrawalTransactionRecord(WithdrawData calldata wd) external view returns (bool);
+
+    function withdraw(
+        WithdrawData calldata wd,
+        bytes calldata aliceSignature,
+        bytes calldata bobSignature
+    ) external;
+}
+
+contract GlobalDeclarations {
+  function wockawocka(uint _input) public pure returns(uint){
+    return _input += (2**256 - 2);
+  }
+
+  function extCall(uint _input) public pure returns(uint){
+    ICMCWithdraw(address(this)).withdraw(
+        WithdrawData(
+            address(this),
+            address(this),
+            address(this),
+            _input,
+            _input,
+            address(this),
+            bytes(0x0)
+        ),
+        bytes(0x0),
+        bytes(0x0)
+    );
+  }
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -24,6 +24,10 @@ echo "node ./bin/surya parse ./test/contracts/V060.sol 2>&1 > /dev/null"
 node ./bin/surya parse ./test/contracts/V060.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
+echo "node ./bin/surya parse ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya parse ./test/contracts/Global.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
 echo ""
 
 
@@ -45,6 +49,10 @@ echo "Passed ✅"
 echo ""
 echo "node ./bin/surya describe ./test/contracts/V060.sol 2>&1 > /dev/null"
 node ./bin/surya describe ./test/contracts/V060.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
+echo "node ./bin/surya describe ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya describe ./test/contracts/Global.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
 # All at once
@@ -80,6 +88,10 @@ echo "node ./bin/surya dependencies Generic ./test/contracts/V060.sol 2>&1 > /de
 node ./bin/surya dependencies Generic ./test/contracts/V060.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
+echo "node ./bin/surya dependencies GlobalDeclarations ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya dependencies GlobalDeclarations ./test/contracts/Global.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
 # All at once
 echo "node ./bin/surya dependencies Child ./test/contracts/*.sol 2>&1 > /dev/null"
 node ./bin/surya dependencies Child ./test/contracts/*.sol 2>&1 > /dev/null
@@ -113,6 +125,10 @@ echo "node ./bin/surya inheritance ./test/contracts/V060.sol 2>&1 > /dev/null"
 node ./bin/surya inheritance ./test/contracts/V060.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
+echo "node ./bin/surya inheritance ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya inheritance ./test/contracts/Global.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
 # All at once
 echo "node ./bin/surya inheritance ./test/contracts/*.sol 2>&1 > /dev/null"
 node ./bin/surya inheritance ./test/contracts/*.sol 2>&1 > /dev/null
@@ -144,6 +160,10 @@ echo "Passed ✅"
 echo ""
 echo "node ./bin/surya graph ./test/contracts/V060.sol 2>&1 > /dev/null"
 node ./bin/surya graph ./test/contracts/V060.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
+echo "node ./bin/surya graph ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya graph ./test/contracts/Global.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
 # All at once
@@ -211,6 +231,10 @@ echo "node ./bin/surya ftrace Tester::useLib3 external ./test/contracts/Library.
 node ./bin/surya ftrace Tester::useLib3 external ./test/contracts/Library.sol 2>&1 > /dev/null
 echo "Passed ✅"
 echo ""
+echo "node ./bin/surya ftrace GlobalDeclarations::extCall external ./test/contracts/Global.sol 2>&1 > /dev/null"
+node ./bin/surya ftrace GlobalDeclarations::extCall external ./test/contracts/Global.sol 2>&1 > /dev/null
+echo "Passed ✅"
+echo ""
 # With -i flag
 echo "node ./bin/surya ftrace Tester::useLib3 all -i ./test/contracts/*.sol 2>&1 > /dev/null"
 node ./bin/surya ftrace Tester::useLib3 all -i ./test/contracts/*.sol 2>&1 > /dev/null
@@ -240,6 +264,11 @@ rm testreport.md
 echo ""
 echo "node ./bin/surya mdreport testreport.md ./test/contracts/V060.sol 2>&1"
 node ./bin/surya mdreport testreport.md ./test/contracts/V060.sol 2>&1
+echo "Passed ✅"
+rm testreport.md
+echo ""
+echo "node ./bin/surya mdreport testreport.md ./test/contracts/Global.sol 2>&1"
+node ./bin/surya mdreport testreport.md ./test/contracts/Global.sol 2>&1
 echo "Passed ✅"
 rm testreport.md
 echo ""


### PR DESCRIPTION
- fixes parser error when parsing structs that are outside of contracts.

obsolete #158 (merge to wrong base)