### PR TITLE
Negative Modifiers Functionality for `mdreport`

### DIFF
--- a/bin/surya
+++ b/bin/surya
@@ -190,10 +190,14 @@ require('yargs') // eslint-disable-line
         alias: 'title-deepness',
         type: 'number',
         default: 2
+      }).option('n', {
+        alias: 'negative-modifiers',
+        type: 'boolean',
+        default: false
       });
   }, (argv) => {
     try {
-      fs.writeFileSync(argv.outfile, mdreport(argv.infiles, {importer: argv.i, deepness: argv.d, contentsInFilePath: argv.c}), {flag: 'w',});
+      fs.writeFileSync(argv.outfile, mdreport(argv.infiles, {importer: argv.i, deepness: argv.d, contentsInFilePath: argv.c, negModifiers: argv.n}), {flag: 'w',});
     } catch (err) {
         console.log('Error in writing report file');
         console.log(err);

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -76,6 +76,11 @@ export function mdreport(infiles, options = {}) {
         if (modifiers.indexOf(node.name) == -1){
           modifiers.push(node.name);
         }
+      },
+      ModifierDefinition: function ModifierDefinition(node){
+        if (modifiers.indexOf(node.name) == -1){
+          modifiers.push(node.name);
+        }
       }
     });
 

--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -27,7 +27,7 @@ export function mdreport(infiles, options = {}) {
 `;
 
   // make the files array unique by typecasting them to a Set and back
-  // this is not needed in case the importer flag is on, because the 
+  // this is not needed in case the importer flag is on, because the
   // importer module already filters the array internally
   if(!options.contentsInFilePath && options.importer) {
     infiles = importer.importProfiler(infiles);
@@ -72,7 +72,7 @@ export function mdreport(infiles, options = {}) {
     var isConstructor = false;
 
     parser.visit(ast, {
-      ModifierDefinition: function ModifierDefinition(node){
+      ModifierInvocation: function ModifierInvocation(node){
         if (modifiers.indexOf(node.name) == -1){
           modifiers.push(node.name);
         }
@@ -155,7 +155,7 @@ export function mdreport(infiles, options = {}) {
             }
           added = [];
         }
-        
+
         contractsTable += ` |
 `;
       },
@@ -164,7 +164,7 @@ export function mdreport(infiles, options = {}) {
         doesModifierExist = true;
         contractsTable += ` ${node.name}`;
         added.push(node.name);
-        
+
       }
     });
   }
@@ -186,6 +186,6 @@ ${'#'.repeat(options.deepness + 1)} Legend
 |    🛑    | Function can modify state |
 |    💵    | Function is payable |
 `;
-  
+
   return reportContents;
 }


### PR DESCRIPTION
I created a feature in my private fork of surya that adds the `-n` parameter to the `mdreport` command. When this parameter is defined, it also lists the modifiers that are NOT present. This may help catch issues relating to missing modifiers.

![image](https://user-images.githubusercontent.com/2998191/155733325-7a6187b8-e63e-4410-a312-aa2a1c940e31.png)


In the above scenario, `onlyMinters`, `onlyMasterMinter`, `checkWhitelist`, are shown to be NOT present. 

Note that the way this is implemented is by running:
```
    parser.visit(ast, {
      ModifierInvocation: function ModifierInvocation(node){
        if (modifiers.indexOf(node.name) == -1){
          modifiers.push(node.name);
        }
      },
      ModifierDefinition: function ModifierDefinition(node){
        if (modifiers.indexOf(node.name) == -1){
          modifiers.push(node.name);
        }
      }
    });
```
before the main call to `parser.visit` to enumerate all of the modifiers called in this file. All modifiers that are invoked AND all modifiers that are defined are evaluated and pushed into an array. That array is used to determine which modifiers are missing. If there is a better implementation for this, I'd love to know.

Thanks, hope others will find this useful as well.
Rhynorater