### PR TITLE
Update solidity-parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.7-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solidity-parser/parser": "^0.14.3",
+        "@solidity-parser/parser": "^0.16.1",
         "c3-linearization": "^0.3.0",
         "colors": "^1.4.0",
         "graphviz": "0.0.9",
@@ -145,9 +145,9 @@
       "dev": true
     },
     "node_modules/@solidity-parser/parser": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.3.tgz",
-      "integrity": "sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.1.tgz",
+      "integrity": "sha512-PdhRFNhbTtu3x8Axm0uYpqOy/lODYQK+MlYSgqIsq2L8SFYEHJPHNUiOTAJbDGzNjjr1/n9AcIayxafR/fWmYw==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -5541,9 +5541,9 @@
       "dev": true
     },
     "@solidity-parser/parser": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.3.tgz",
-      "integrity": "sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.1.tgz",
+      "integrity": "sha512-PdhRFNhbTtu3x8Axm0uYpqOy/lODYQK+MlYSgqIsq2L8SFYEHJPHNUiOTAJbDGzNjjr1/n9AcIayxafR/fWmYw==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^5.1.1"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.14.3",
+    "@solidity-parser/parser": "^0.16.1",
     "c3-linearization": "^0.3.0",
     "colors": "^1.4.0",
     "graphviz": "0.0.9",


### PR DESCRIPTION
`solidity-parser/parser` now supports named parameters in mapping types and user-defined operators.

Closes #179