### PR TITLE
Feat/correctly handle dependencies in super call

### DIFF
--- a/src/ftrace.js
+++ b/src/ftrace.js
@@ -486,9 +486,13 @@ export function ftrace(functionId, accepted_visibility, files, options = {}, noC
           if(object === null) {
             return;
           } else if (object === 'super') {
-            // "super" in this context is gonna be the 3rd element of the dependencies array
-            // since the first is the global scope and the second is the contract itself
-            localContractName = dependencies[contractName][2];
+            let matchingContracts = [...dependencies[contractName]].filter(contract => functionsPerContract[contract].includes(name));
+
+            if(matchingContracts.length > 0){
+              localContractName = matchingContracts[0];
+            } else {
+              return;
+            }
           } else if (tempUserDefinedStateVars[object] !== undefined) {
             localContractName = tempUserDefinedStateVars[object];
           } else if (userDefinedLocalVars[object] !== undefined) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -500,9 +500,13 @@ export function graph(files, options = {}) {
           } else if(object === 'this') {
             opts.color = colorScheme.call.this;
           } else if (object === 'super') {
-            // "super" in this context is gonna be the 2nd element of the dependencies array
-            // since the first is the contract itself
-            localContractName = dependencies[contractName][1];
+            let matchingContracts = [...dependencies[contractName]].filter(contract => functionsPerContract[contract].includes(name));
+
+            if(matchingContracts.length > 0){
+              localContractName = matchingContracts[0];
+            } else {
+              return;
+            }
           } else if (tempUserDefinedStateVars[object] !== undefined) {
             localContractName = tempUserDefinedStateVars[object];
           } else if (userDefinedLocalVars[object] !== undefined) {

--- a/test/contracts/Inheritance.sol
+++ b/test/contracts/Inheritance.sol
@@ -16,3 +16,17 @@ contract FourthParent {}
 // Linearization is _something_ like this:
 // Child
 // └─ FirstParent <- SecondParent <- ThirdParent <- FourthParent <- IThirdParent
+
+abstract contract A {
+    function fooA() public pure returns (string memory) {
+        return "A";
+    }
+}
+
+abstract contract B {}
+
+contract C is A, B {
+    function fooC() public pure returns (string memory) {
+        return super.fooA();
+    }
+}


### PR DESCRIPTION
Change in the way to decode "super" method usage. Fixes cases where the inheritance was being mishandled where contracts have multiple inheritance.

Fixes #189.