### PR TITLE
Fix/wrong nodename in special functions

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -199,7 +199,10 @@ export function graph(files, options = {}) {
     let cluster = null;
 
     function nodeName(functionName, contractName) {
-      if (dependencies.hasOwnProperty(contractName)) {
+      if (
+        functionName !== '<Fallback>' && functionName !== '<Receive Ether>' && functionName !== '<Constructor>'
+        && dependencies.hasOwnProperty(contractName)
+      ) {
         for (let dep of dependencies[contractName]) {
           const name = `${dep}.${functionName}`;
           if (digraph.getNode(name)) {

--- a/test/contracts/Inheritance.sol
+++ b/test/contracts/Inheritance.sol
@@ -30,3 +30,26 @@ contract C is A, B {
         return super.fooA();
     }
 }
+
+abstract contract Foo {
+    string private _fooA;
+    string private _fooB;
+
+    constructor(string memory fooA_) {
+        _setFooA(fooA_);
+    }
+    
+    function _setFooA(string memory fooA_) internal {
+        _fooA = fooA_;
+    }
+    
+    function _setFooB(string memory fooB_) internal {
+        _fooB = fooB_;
+    }
+}
+
+contract MyContract is Foo {
+    constructor() Foo("A") {
+        super._setFooB("B");
+    }
+}


### PR DESCRIPTION
Fix for the wrong codename resolution bug in special functions like `<Constructor>`, `<Receive Ether>`, and `<Fallback>`.