### PR TITLE
fix sha1 hash in mdreport printing "object promise"

### DIFF
--- a/src/mdreport.js
+++ b/src/mdreport.js
@@ -36,7 +36,7 @@ export function mdreport(infiles, options = {}) {
   }
 
   for (let file of infiles) {
-    filesTable += `| ${file} | ${sha1File(file)} |
+    filesTable += `| ${file} | ${sha1File.sync(file)} |
 `;
 
     if(!options.contentsInFilePath) {


### PR DESCRIPTION
fixes "object promise", see https://www.npmjs.com/package/sha1-file?activeTab=readme

problem:
<img width="80" alt="image" src="https://github.com/user-attachments/assets/021bb291-2677-4ac5-89cf-6fb927ee46af">

fixed:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/34025ed6-6cce-4740-b34d-9865eb5ae39a">
